### PR TITLE
Whitespace can now be specified via list of characters or predicate

### DIFF
--- a/string_trim.hpp
+++ b/string_trim.hpp
@@ -5,22 +5,29 @@
 #include <iterator>
 #include <algorithm>
 
-template<typename Predicate,typename CharacterType,bool = std::is_invocable_v<Predicate,CharacterType>>
-struct is_whitespace_predicate_impl{
-    static constexpr bool value=false;
+template <
+    typename Predicate, typename CharacterType,
+    bool= std::is_invocable_v<Predicate, CharacterType>>
+struct is_whitespace_predicate_impl {
+    static constexpr bool value= false;
 };
 
-template<typename Predicate,typename CharacterType>
-struct is_whitespace_predicate_impl<Predicate,CharacterType,true>{
-    static constexpr bool value=std::is_convertible_v<decltype(std::declval<Predicate>()(std::declval<CharacterType>())),bool>;
+template <typename Predicate, typename CharacterType>
+struct is_whitespace_predicate_impl<Predicate, CharacterType, true> {
+    static constexpr bool value= std::is_convertible_v<
+        decltype(std::declval<Predicate>()(std::declval<CharacterType>())),
+        bool>;
 };
 
-template<typename Predicate,typename CharacterType>
-constexpr bool is_whitespace_predicate = is_whitespace_predicate_impl<Predicate,CharacterType>::value;
+template <typename Predicate, typename CharacterType>
+constexpr bool is_whitespace_predicate=
+    is_whitespace_predicate_impl<Predicate, CharacterType>::value;
 
 template <typename Iterator>
 typename std::enable_if<
-    std::is_same_v<char, std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type> >,
+    std::is_same_v<
+        char,
+        std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>>,
     Iterator>::type
 find_first_non_whitespace(Iterator begin, Iterator end) {
     auto pos= begin;
@@ -31,7 +38,9 @@ find_first_non_whitespace(Iterator begin, Iterator end) {
 
 template <typename Iterator>
 typename std::enable_if<
-    std::is_same_v<wchar_t, std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type> >,
+    std::is_same_v<
+        wchar_t,
+        std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>>,
     Iterator>::type
 find_first_non_whitespace(Iterator begin, Iterator end) {
     auto pos= begin;
@@ -40,48 +49,61 @@ find_first_non_whitespace(Iterator begin, Iterator end) {
     return pos;
 }
 
-template<typename Iterator,typename CharacterList>
+template <typename Iterator, typename CharacterList>
 typename std::enable_if<
-    !is_whitespace_predicate<CharacterList, typename std::iterator_traits<Iterator>::value_type>,
+    !is_whitespace_predicate<
+        CharacterList, typename std::iterator_traits<Iterator>::value_type>,
     Iterator>::type
-find_first_non_whitespace(Iterator begin,Iterator end,CharacterList&& space_chars){
-    auto pos=begin;
-    auto begin_of_chars=std::begin(space_chars);
-    auto end_of_chars=std::end(space_chars);
-    for(;(pos!=end) && (std::find(begin_of_chars,end_of_chars,*pos)!=end_of_chars);++pos);
+find_first_non_whitespace(
+    Iterator begin, Iterator end, CharacterList &&space_chars) {
+    auto pos= begin;
+    auto begin_of_chars= std::begin(space_chars);
+    auto end_of_chars= std::end(space_chars);
+    for(; (pos != end) &&
+          (std::find(begin_of_chars, end_of_chars, *pos) != end_of_chars);
+        ++pos)
+        ;
     return pos;
 }
 
-template<typename Iterator,typename Predicate>
+template <typename Iterator, typename Predicate>
 typename std::enable_if<
-    is_whitespace_predicate<Predicate, typename std::iterator_traits<Iterator>::value_type>,
+    is_whitespace_predicate<
+        Predicate, typename std::iterator_traits<Iterator>::value_type>,
     Iterator>::type
-find_first_non_whitespace(Iterator begin,Iterator end,Predicate&& is_white_space){
-    auto pos=begin;
-    for(;(pos!=end) && is_white_space(*pos);++pos);
+find_first_non_whitespace(
+    Iterator begin, Iterator end, Predicate &&is_white_space) {
+    auto pos= begin;
+    for(; (pos != end) && is_white_space(*pos); ++pos)
+        ;
     return pos;
 }
 
-
-template<typename Iterator>
+template <typename Iterator>
 typename std::enable_if<
-    std::is_same_v<char, std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type> >,
+    std::is_same_v<
+        char,
+        std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>>,
     Iterator>::type
-find_last_non_whitespace(Iterator begin,Iterator end){
+find_last_non_whitespace(Iterator begin, Iterator end) {
     auto endpos= std::make_reverse_iterator(end);
     for(auto start= std::make_reverse_iterator(begin);
-        (endpos != start) && std::isspace(*endpos); ++endpos);
+        (endpos != start) && std::isspace(*endpos); ++endpos)
+        ;
     return endpos.base();
 }
 
-template<typename Iterator>
+template <typename Iterator>
 typename std::enable_if<
-    std::is_same_v<wchar_t, std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type> >,
+    std::is_same_v<
+        wchar_t,
+        std::remove_cv_t<typename std::iterator_traits<Iterator>::value_type>>,
     Iterator>::type
-find_last_non_whitespace(Iterator begin,Iterator end){
+find_last_non_whitespace(Iterator begin, Iterator end) {
     auto endpos= std::make_reverse_iterator(end);
     for(auto start= std::make_reverse_iterator(begin);
-        (endpos != start) && std::iswspace(*endpos); ++endpos);
+        (endpos != start) && std::iswspace(*endpos); ++endpos)
+        ;
     return endpos.base();
 }
 
@@ -99,18 +121,15 @@ Iterator find_last_non_whitespace(
     return endpos.base();
 }
 
-template<typename Container>
-void trim_left(Container& s){
-    s.erase(s.begin(),find_first_non_whitespace(s.begin(),s.end()));
+template <typename Container> void trim_left(Container &s) {
+    s.erase(s.begin(), find_first_non_whitespace(s.begin(), s.end()));
 }
 
-template<typename Container>
-void trim_right(Container& s){
-    s.erase(find_last_non_whitespace(s.begin(),s.end()),s.end());
+template <typename Container> void trim_right(Container &s) {
+    s.erase(find_last_non_whitespace(s.begin(), s.end()), s.end());
 }
 
-template<typename Container>
-void trim(Container& s){
+template <typename Container> void trim(Container &s) {
     trim_left(s);
     trim_right(s);
 }
@@ -137,9 +156,9 @@ void trim_left(Container &s, typename Container::value_type *space_chars) {
         s, std::basic_string_view<typename Container::value_type>(space_chars));
 }
 
-template<typename Container,typename CharacterList>
-void trim_right(Container& s,CharacterList&& space_chars){
-    s.erase(find_last_non_whitespace(s.begin(),s.end(),space_chars),s.end());
+template <typename Container, typename CharacterList>
+void trim_right(Container &s, CharacterList &&space_chars) {
+    s.erase(find_last_non_whitespace(s.begin(), s.end(), space_chars), s.end());
 }
 
 template <typename Container>
@@ -164,27 +183,25 @@ trim_left(Container &s, Predicate &&predicate) {
         s.begin(), find_first_non_whitespace(s.begin(), s.end(), predicate));
 }
 
-template<typename Container>
-std::remove_reference_t<Container> trim_copy_left(Container&& s){
-    using string_type=std::remove_reference_t<Container>;
-    return string_type(find_first_non_whitespace(s.begin(),s.end()),s.end());
+template <typename Container>
+std::remove_reference_t<Container> trim_copy_left(Container &&s) {
+    using string_type= std::remove_reference_t<Container>;
+    return string_type(find_first_non_whitespace(s.begin(), s.end()), s.end());
 }
 
-template<typename Container>
-std::remove_reference_t<Container> trim_copy_right(Container&& s){
-    using string_type=std::remove_reference_t<Container>;
-    return string_type(s.begin(),find_last_non_whitespace(s.begin(),s.end()));
+template <typename Container>
+std::remove_reference_t<Container> trim_copy_right(Container &&s) {
+    using string_type= std::remove_reference_t<Container>;
+    return string_type(s.begin(), find_last_non_whitespace(s.begin(), s.end()));
 }
 
-template<typename Container>
-std::remove_reference_t<Container> trim_copy(Container&& s){
-    using string_type=std::remove_reference_t<Container>;
-    auto const begin=s.begin();
-    auto const end=s.end();
-    auto const copy_begin=find_first_non_whitespace(begin,end);
-    return (copy_begin==end)?string_type(end,end):
-        string_type(
-        copy_begin,
-        find_last_non_whitespace(begin,end));
+template <typename Container>
+std::remove_reference_t<Container> trim_copy(Container &&s) {
+    using string_type= std::remove_reference_t<Container>;
+    auto const begin= s.begin();
+    auto const end= s.end();
+    auto const copy_begin= find_first_non_whitespace(begin, end);
+    return (copy_begin == end) ?
+               string_type(end, end) :
+               string_type(copy_begin, find_last_non_whitespace(begin, end));
 }
-

--- a/string_trim.hpp
+++ b/string_trim.hpp
@@ -218,10 +218,56 @@ std::remove_reference_t<Container> trim_copy_left(Container &&s) {
     return string_type(find_first_non_whitespace(s.begin(), s.end()), s.end());
 }
 
+template <typename Container, typename CharacterListOrPredicate>
+std::remove_reference_t<Container> trim_copy_left(
+    Container &&s, CharacterListOrPredicate &&space_chars_or_predicate) {
+    using string_type= std::remove_reference_t<Container>;
+    return string_type(
+        find_first_non_whitespace(s.begin(), s.end(), space_chars_or_predicate),
+        s.end());
+}
+
+template <typename Container>
+std::remove_reference_t<Container> trim_copy_left(
+    Container &s, typename Container::value_type const *space_chars) {
+    return trim_copy_left(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
+}
+
+template <typename Container>
+std::remove_reference_t<Container>
+trim_copy_left(Container &s, typename Container::value_type *space_chars) {
+    return trim_copy_left(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
+}
+
 template <typename Container>
 std::remove_reference_t<Container> trim_copy_right(Container &&s) {
     using string_type= std::remove_reference_t<Container>;
     return string_type(s.begin(), find_last_non_whitespace(s.begin(), s.end()));
+}
+
+template <typename Container, typename CharacterListOrPredicate>
+std::remove_reference_t<Container> trim_copy_right(
+    Container &&s, CharacterListOrPredicate &&space_chars_or_predicate) {
+    using string_type= std::remove_reference_t<Container>;
+    return string_type(
+        s.begin(),
+        find_last_non_whitespace(s.begin(), s.end(), space_chars_or_predicate));
+}
+
+template <typename Container>
+std::remove_reference_t<Container> trim_copy_right(
+    Container &s, typename Container::value_type const *space_chars) {
+    return trim_copy_right(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
+}
+
+template <typename Container>
+std::remove_reference_t<Container>
+trim_copy_right(Container &s, typename Container::value_type *space_chars) {
+    return trim_copy_right(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
 }
 
 template <typename Container>
@@ -233,4 +279,33 @@ std::remove_reference_t<Container> trim_copy(Container &&s) {
     return (copy_begin == end) ?
                string_type(end, end) :
                string_type(copy_begin, find_last_non_whitespace(begin, end));
+}
+
+template <typename Container, typename CharacterListOrPredicate>
+std::remove_reference_t<Container>
+trim_copy(Container &&s, CharacterListOrPredicate &&space_chars_or_predicate) {
+    using string_type= std::remove_reference_t<Container>;
+    auto const begin= s.begin();
+    auto const end= s.end();
+    auto const copy_begin=
+        find_first_non_whitespace(begin, end, space_chars_or_predicate);
+    return (copy_begin == end) ?
+               string_type(end, end) :
+               string_type(
+                   copy_begin, find_last_non_whitespace(
+                                   begin, end, space_chars_or_predicate));
+}
+
+template <typename Container>
+std::remove_reference_t<Container>
+trim_copy(Container &s, typename Container::value_type const *space_chars) {
+    return trim_copy(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
+}
+
+template <typename Container>
+std::remove_reference_t<Container>
+trim_copy(Container &s, typename Container::value_type *space_chars) {
+    return trim_copy(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
 }

--- a/string_trim.hpp
+++ b/string_trim.hpp
@@ -174,6 +174,29 @@ void trim_right(Container &s, typename Container::value_type *space_chars) {
         s, std::basic_string_view<typename Container::value_type>(space_chars));
 }
 
+template <typename Container, typename CharacterList>
+typename std::enable_if<
+    !is_whitespace_predicate<CharacterList, typename Container::value_type>,
+    void>::type
+trim(Container &s, CharacterList &&space_chars) {
+    trim_left(s,space_chars);
+    trim_right(s,space_chars);
+}
+
+template <typename Container>
+void trim(
+    Container &s, typename Container::value_type const *space_chars) {
+    trim(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
+}
+
+template <typename Container>
+void trim(Container &s, typename Container::value_type *space_chars) {
+    trim(
+        s, std::basic_string_view<typename Container::value_type>(space_chars));
+}
+
+
 template <typename Container, typename Predicate>
 typename std::enable_if<
     is_whitespace_predicate<Predicate, typename Container::value_type>,

--- a/string_trim_tests.cpp
+++ b/string_trim_tests.cpp
@@ -359,6 +359,16 @@ void trim_right_with_specified_characters_via_string(){
     assert(s==hello);
 }
 
+void trim_left_with_predicate(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello;
+    auto s=orig;
+    trim_left(s,[](char c){
+            return c=='a' || c=='b';
+        });
+    assert(s==hello);
+}
+
 int main(){
     trim_empty_string_does_nothing();
     trim_non_space_string_does_nothing();
@@ -402,4 +412,5 @@ int main(){
     trim_right_with_specified_characters_via_char_pointer();
     trim_right_with_specified_characters_via_non_const_char_pointer();
     trim_right_with_specified_characters_via_string();
+    trim_left_with_predicate();
 }

--- a/string_trim_tests.cpp
+++ b/string_trim_tests.cpp
@@ -369,6 +369,42 @@ void trim_left_with_predicate(){
     assert(s==hello);
 }
 
+void trim_both_with_specified_characters(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    trim(s,"ab");
+    assert(s==hello);
+}
+
+void trim_both_with_specified_characters_via_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    char const* space_chars="ab";
+    trim(s,space_chars);
+    assert(s==hello);
+}
+
+void trim_both_with_specified_characters_via_non_const_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    char space_chars[]="ab";
+    char* space_chars_ptr=space_chars;
+    trim(s,space_chars_ptr);
+    assert(s==hello);
+}
+
+void trim_both_with_specified_characters_via_string(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    std::string const space_chars="ab";
+    trim(s,space_chars);
+    assert(s==hello);
+}
+
 int main(){
     trim_empty_string_does_nothing();
     trim_non_space_string_does_nothing();
@@ -413,4 +449,8 @@ int main(){
     trim_right_with_specified_characters_via_non_const_char_pointer();
     trim_right_with_specified_characters_via_string();
     trim_left_with_predicate();
+    trim_both_with_specified_characters();
+    trim_both_with_specified_characters_via_char_pointer();
+    trim_both_with_specified_characters_via_non_const_char_pointer();
+    trim_both_with_specified_characters_via_string();
 }

--- a/string_trim_tests.cpp
+++ b/string_trim_tests.cpp
@@ -425,6 +425,159 @@ void trim_both_with_predicate(){
     assert(s==hello);
 }
 
+void trim_copy_left_with_specified_characters(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello;
+    auto s=orig;
+    auto s2=trim_copy_left(s,"ab");
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_left_with_specified_characters_via_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello;
+    auto s=orig;
+    char const* space_chars="ab";
+    auto s2=trim_copy_left(s,space_chars);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_left_with_specified_characters_via_non_const_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello;
+    auto s=orig;
+    char space_chars[]="ab";
+    char* space_chars_ptr=space_chars;
+    auto s2=trim_copy_left(s,space_chars_ptr);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_left_with_specified_characters_via_string(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello;
+    auto s=orig;
+    std::string const space_chars="ab";
+    auto s2=trim_copy_left(s,space_chars);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_right_with_specified_characters(){
+    std::string const hello="hello";
+    std::string const orig=hello+"aaabbabab";
+    auto s=orig;
+    auto s2=trim_copy_right(s,"ab");
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_right_with_specified_characters_via_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig=hello+"aaabbabab";
+    auto s=orig;
+    char const* space_chars="ab";
+    auto s2=trim_copy_right(s,space_chars);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_right_with_specified_characters_via_non_const_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig=hello+"aaabbabab";
+    auto s=orig;
+    char space_chars[]="ab";
+    char* space_chars_ptr=space_chars;
+    auto s2=trim_copy_right(s,space_chars_ptr);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_right_with_specified_characters_via_string(){
+    std::string const hello="hello";
+    std::string const orig=hello+"aaabbabab";
+    auto s=orig;
+    std::string const space_chars="ab";
+    auto s2=trim_copy_right(s,space_chars);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_left_with_predicate(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello;
+    auto s=orig;
+    auto s2=trim_copy_left(s,[](char c){
+            return c=='a' || c=='b';
+        });
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_both_with_specified_characters(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    auto s2=trim_copy(s,"ab");
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_both_with_specified_characters_via_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    char const* space_chars="ab";
+    auto s2=trim_copy(s,space_chars);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_both_with_specified_characters_via_non_const_char_pointer(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    char space_chars[]="ab";
+    char* space_chars_ptr=space_chars;
+    auto s2=trim_copy(s,space_chars_ptr);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_both_with_specified_characters_via_string(){
+    std::string const hello="hello";
+    std::string const orig="aaabbbabab"+hello+"aaabbabab";
+    auto s=orig;
+    std::string const space_chars="ab";
+    auto s2=trim_copy(s,space_chars);
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_right_with_predicate(){
+    std::string const hello="hello";
+    std::string const orig=hello+"aaabbabab";
+    auto s=orig;
+    auto s2=trim_copy_right(s,[](char c){
+            return c=='a' || c=='b';
+        });
+    assert(s2==hello);
+    assert(s==orig);
+}
+
+void trim_copy_both_with_predicate(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello+"aaabbabab";
+    auto s=orig;
+    auto s2=trim_copy(s,[](char c){
+            return c=='a' || c=='b';
+        });
+    assert(s2==hello);
+    assert(s==orig);
+}
+
 int main(){
     trim_empty_string_does_nothing();
     trim_non_space_string_does_nothing();
@@ -475,4 +628,19 @@ int main(){
     trim_left_with_predicate();
     trim_right_with_predicate();
     trim_both_with_predicate();
+    trim_copy_left_with_specified_characters();
+    trim_copy_left_with_specified_characters_via_char_pointer();
+    trim_copy_left_with_specified_characters_via_non_const_char_pointer();
+    trim_copy_left_with_specified_characters_via_string();
+    trim_copy_right_with_specified_characters();
+    trim_copy_right_with_specified_characters_via_char_pointer();
+    trim_copy_right_with_specified_characters_via_non_const_char_pointer();
+    trim_copy_right_with_specified_characters_via_string();
+    trim_copy_both_with_specified_characters();
+    trim_copy_both_with_specified_characters_via_char_pointer();
+    trim_copy_both_with_specified_characters_via_non_const_char_pointer();
+    trim_copy_both_with_specified_characters_via_string();
+    trim_copy_left_with_predicate();
+    trim_copy_right_with_predicate();
+    trim_copy_both_with_predicate();
 }

--- a/string_trim_tests.cpp
+++ b/string_trim_tests.cpp
@@ -459,20 +459,20 @@ int main(){
     trim_vector_copy_spaces_from_both_ends();
     trim_vector_copy_spaces_from_left_only();
     trim_vector_copy_spaces_from_right_only();
+    trim_spaces_and_tabs_from_both_ends_wide_chars();
     trim_left_with_specified_characters();
     trim_left_with_specified_characters_via_char_pointer();
     trim_left_with_specified_characters_via_non_const_char_pointer();
     trim_left_with_specified_characters_via_string();
-    trim_spaces_and_tabs_from_both_ends_wide_chars();
     trim_right_with_specified_characters();
     trim_right_with_specified_characters_via_char_pointer();
     trim_right_with_specified_characters_via_non_const_char_pointer();
     trim_right_with_specified_characters_via_string();
-    trim_left_with_predicate();
     trim_both_with_specified_characters();
     trim_both_with_specified_characters_via_char_pointer();
     trim_both_with_specified_characters_via_non_const_char_pointer();
     trim_both_with_specified_characters_via_string();
+    trim_left_with_predicate();
     trim_right_with_predicate();
     trim_both_with_predicate();
 }

--- a/string_trim_tests.cpp
+++ b/string_trim_tests.cpp
@@ -405,6 +405,26 @@ void trim_both_with_specified_characters_via_string(){
     assert(s==hello);
 }
 
+void trim_right_with_predicate(){
+    std::string const hello="hello";
+    std::string const orig=hello+"aaabbabab";
+    auto s=orig;
+    trim_right(s,[](char c){
+            return c=='a' || c=='b';
+        });
+    assert(s==hello);
+}
+
+void trim_both_with_predicate(){
+    std::string const hello="hello";
+    std::string const orig="aaabbabab"+hello+"aaabbabab";
+    auto s=orig;
+    trim(s,[](char c){
+            return c=='a' || c=='b';
+        });
+    assert(s==hello);
+}
+
 int main(){
     trim_empty_string_does_nothing();
     trim_non_space_string_does_nothing();
@@ -453,4 +473,6 @@ int main(){
     trim_both_with_specified_characters_via_char_pointer();
     trim_both_with_specified_characters_via_non_const_char_pointer();
     trim_both_with_specified_characters_via_string();
+    trim_right_with_predicate();
+    trim_both_with_predicate();
 }


### PR DESCRIPTION
Updated all versions of trim, trim_left, trim_right, trim_copy_left, trim_copy_right and trim_copy to handle character lists or predicates.